### PR TITLE
enable flatpak option build

### DIFF
--- a/io.github.AllanChain.sane-break.yml
+++ b/io.github.AllanChain.sane-break.yml
@@ -37,6 +37,7 @@ modules:
     buildsystem: cmake-ninja
     config-opts:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      - -DLINUX_DIST=Flatpak
     sources:
       - type: git
         url: https://github.com/AllanChain/sane-break.git


### PR DESCRIPTION
Sane Break have Flatpak-specific logics, such as requesting autostart.